### PR TITLE
Use Optimove initialVisitorId for Optimobile installId

### DIFF
--- a/OptimoveSDK/Sources/Classes/SDK/Kumulos.swift
+++ b/OptimoveSDK/Sources/Classes/SDK/Kumulos.swift
@@ -121,7 +121,7 @@ open class Kumulos {
         - Parameters:
               - config: An instance of KSConfig
     */
-    internal static func initialize(config: OptimobileConfig) {
+    internal static func initialize(config: OptimobileConfig, initialVisitorId: String) {
         if (instance !== nil) {
             assertionFailure("The KumulosSDK has already been initialized")
         }
@@ -131,6 +131,7 @@ open class Kumulos {
         KeyValPersistenceHelper.set(config.secretKey, forKey: KumulosUserDefaultsKey.SECRET_KEY.rawValue)
         KeyValPersistenceHelper.set(config.baseUrlMap[.events], forKey: KumulosUserDefaultsKey.EVENTS_BASE_URL.rawValue)
         KeyValPersistenceHelper.set(config.baseUrlMap[.media], forKey: KumulosUserDefaultsKey.MEDIA_BASE_URL.rawValue)
+        KeyValPersistenceHelper.set(initialVisitorId, forKey: KumulosUserDefaultsKey.INSTALL_UUID.rawValue)
 
         instance = Kumulos(config: config)
 


### PR DESCRIPTION
Refactor the Kumulos installId to use the Optimove initialVisitorId instead.

The initialVisitorId is also a UUIDv4 so this change should be transparent to the Optimobile implementation.

In order to achieve this in cases where Optimove credentials are not yet provided, we need to re-arrange the initialisation of some dependencies in the container.

Move the Logger init from configure, and the new visitor ID generation from startSdk into the Optimove init() method instead.