### PR TITLE
Update Optimobile SDK meta-data

### DIFF
--- a/OptimobileShared/AppGroupsHelper.swift
+++ b/OptimobileShared/AppGroupsHelper.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct AppGroupConfig {
-    public static var suffix : String = ".kumulos"
+    public static var suffix : String = ".optimove"
 }
 
 internal class AppGroupsHelper {

--- a/OptimoveSDK/Sources/Classes/SDK/Kumulos+Stats.swift
+++ b/OptimoveSDK/Sources/Classes/SDK/Kumulos+Stats.swift
@@ -18,13 +18,6 @@ enum OSTypeID: NSNumber {
     case osTypeIDWindow
 }
 
-enum SDKTypeID: NSNumber {
-    case sdkTypeObjC = 1
-    case sdkTypeJavaSDK
-    case sdkTypeCSharp
-    case sdkTypeSwift
-}
-
 enum RuntimeType: NSNumber {
     case runtimeTypeUnknown = 0
     case runtimeTypeNative
@@ -76,7 +69,7 @@ public extension Kumulos{
         
         
         var sdk = [String : AnyObject]()
-        sdk["id"] = SDKTypeID.sdkTypeSwift.rawValue
+        sdk["id"] = sdkType as AnyObject
         sdk["version"] = sdkVersion as AnyObject
         
         var runtime = [String : AnyObject]()

--- a/OptimoveSDK/Sources/Classes/SDK/Kumulos.swift
+++ b/OptimoveSDK/Sources/Classes/SDK/Kumulos.swift
@@ -46,7 +46,8 @@ open class Kumulos {
     internal let pushNotificationDeviceType = 1
     internal let pushNotificationProductionTokenType:Int = 1
 
-    internal let sdkVersion : String = "9.2.5"
+    internal let sdkVersion : String = "4.0.0"
+    internal let sdkType : Int = 101;
 
     fileprivate static var instance:Kumulos?
 


### PR DESCRIPTION
Update expected app groups suffix to `optimove`, and set SDK type and version consts for Optimove Swift SDK and expected release version.