### PR TITLE
Bump version for 5.x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 3.6.0
+## 5.0.0
+
+Major breaking update - [Migration guide](https://github.com/optimove-tech/Optimove-SDK-iOS/wiki/Migration-guide-from-3.x-to-5.x)
+
+- Deprecated OptiPush and implemented new messaging platform
+- Added In-App Messaging, Message Inbox and Deferred Deep Linking features
+
+## 3.6.0 (unreleased)
 
 - **added** `getVisitorID` API.
 

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '3.6.0'
+  s.version          = '5.0.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "3.6.0"
+public let SDKVersion = "5.0.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '3.6.0'
+  s.version          = '5.0.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '3.6.0'
+  s.version          = '5.0.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Stats.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Stats.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import UserNotifications
+import OptimoveCore
 
 #if os(iOS) || os(watchOS) || os(tvOS)
     import UIKit
@@ -67,7 +68,7 @@ extension Optimobile {
         
         var sdk = [String : AnyObject]()
         sdk["id"] = sdkType as AnyObject
-        sdk["version"] = sdkVersion as AnyObject
+        sdk["version"] = SDKVersion as AnyObject
         
         var runtime = [String : AnyObject]()
         var os = [String : AnyObject]()

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -43,7 +43,6 @@ class Optimobile {
     let pushNotificationDeviceType = 1
     let pushNotificationProductionTokenType:Int = 1
 
-    let sdkVersion : String = "4.0.0"
     let sdkType : Int = 101;
 
     fileprivate static var instance:Optimobile?


### PR DESCRIPTION
Note we are skipping the 4.x version to align both iOS & Android SDK versions. This
makes it simpler for discussing which SDK version is required for Optimobile support.

Add changelog entries, update podspecs, and code-level version const.