### PR TITLE
Notify Optimobile about existing user associations

### DIFF
--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -115,7 +115,7 @@ class Optimobile {
     /**
         Initialize the Optimobile SDK.
     */
-    static func initialize(config: OptimobileConfig, initialVisitorId: String) {
+    static func initialize(config: OptimobileConfig, initialVisitorId: String, initialUserId: String) {
         if (instance !== nil) {
             assertionFailure("The OptimobileSDK has already been initialized")
         }
@@ -140,6 +140,17 @@ class Optimobile {
         DispatchQueue.global().async {
             instance!.sendDeviceInformation()
         }
+        
+        maybeAlignUserAssociation(initialUserId)
+    }
+    
+    fileprivate static func maybeAlignUserAssociation(instance: Optimobile, initialUserId: String) {
+        String optimobileUserId = instance.currentUserIdentifier
+        if (optimobileUserId == initialUserId) {
+            return
+        }
+            
+        instance.associateUserWithInstall(userIdentifier: initialUserId)
     }
 
     fileprivate init(config: OptimobileConfig) {

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -141,20 +141,20 @@ class Optimobile {
             instance!.sendDeviceInformation()
         }
         
-        maybeAlignUserAssociation(initialUserId)
+        maybeAlignUserAssociation(initialUserId: initialUserId)
     }
     
-    fileprivate static func maybeAlignUserAssociation(instance: Optimobile, initialUserId: String?) {
+    fileprivate static func maybeAlignUserAssociation(initialUserId: String?) {
         if (initialUserId == nil) {
             return
         }
         
-        String optimobileUserId = instance.currentUserIdentifier
+        let optimobileUserId = OptimobileHelper.currentUserIdentifier
         if (optimobileUserId == initialUserId) {
             return
         }
             
-        instance.associateUserWithInstall(userIdentifier: initialUserId)
+        Optimobile.associateUserWithInstall(userIdentifier: initialUserId!)
     }
 
     fileprivate init(config: OptimobileConfig) {

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -115,7 +115,7 @@ class Optimobile {
     /**
         Initialize the Optimobile SDK.
     */
-    static func initialize(config: OptimobileConfig, initialVisitorId: String, initialUserId: String) {
+    static func initialize(config: OptimobileConfig, initialVisitorId: String, initialUserId: String?) {
         if (instance !== nil) {
             assertionFailure("The OptimobileSDK has already been initialized")
         }
@@ -144,7 +144,11 @@ class Optimobile {
         maybeAlignUserAssociation(initialUserId)
     }
     
-    fileprivate static func maybeAlignUserAssociation(instance: Optimobile, initialUserId: String) {
+    fileprivate static func maybeAlignUserAssociation(instance: Optimobile, initialUserId: String?) {
+        if (initialUserId == nil) {
+            return
+        }
+        
         String optimobileUserId = instance.currentUserIdentifier
         if (optimobileUserId == initialUserId) {
             return
@@ -190,5 +194,5 @@ class Optimobile {
         pushHttpClient.invalidateSessionCancellingTasks(true)
         coreHttpClient.invalidateSessionCancellingTasks(true)
     }
-
+    
 }

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -58,9 +58,7 @@ typealias Logger = OptimoveCore.Logger
                     return
                 }
                 
-                guard let userId = try? serviceLocator.storage().getCustomerID() else {
-                    userId = nil
-                }
+                let userId = try? serviceLocator.storage().getCustomerID()
 
                 Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId, initialUserId: userId)
             }

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -58,11 +58,27 @@ typealias Logger = OptimoveCore.Logger
                     return
                 }
 
+                maybeAlignUserAssociation();
+                
                 Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId)
             }
         }
     }
+    
+    private static func maybeAlignUserAssociation() {
+        shared.container.resolve { serviceLocator in
+            guard let userId = try? serviceLocator.storage().getCustomerID() else {
+                return
+            }
 
+            String optimobileUserId = Optimobile.currentUserIdentifier
+            if (optimobileUserId == customerId) {
+                return
+            }
+                
+            Optimobile.associateUserWithInstall(userIdentifier: userId)
+        }
+    }
 }
 
 // MARK: - Event API call

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -59,13 +59,14 @@ typealias Logger = OptimoveCore.Logger
                 }
                 
                 guard let userId = try? serviceLocator.storage().getCustomerID() else {
-                    return
+                    userId = nil
                 }
 
                 Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId, initialUserId: userId)
             }
         }
     }
+
 }
 
 // MARK: - Event API call
@@ -362,5 +363,5 @@ private extension Optimove {
         }
         container.resolve(function)
     }
-
+    
 }

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -57,26 +57,13 @@ typealias Logger = OptimoveCore.Logger
                 guard let visitorId = try? serviceLocator.storage().getInitialVisitorId() else {
                     return
                 }
-
-                maybeAlignUserAssociation();
                 
-                Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId)
-            }
-        }
-    }
-    
-    private static func maybeAlignUserAssociation() {
-        shared.container.resolve { serviceLocator in
-            guard let userId = try? serviceLocator.storage().getCustomerID() else {
-                return
-            }
+                guard let userId = try? serviceLocator.storage().getCustomerID() else {
+                    return
+                }
 
-            String optimobileUserId = Optimobile.currentUserIdentifier
-            if (optimobileUserId == customerId) {
-                return
+                Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId, initialUserId: userId)
             }
-                
-            Optimobile.associateUserWithInstall(userIdentifier: userId)
         }
     }
 }


### PR DESCRIPTION
### Description of Changes

During initialization the Optimobile backend should be notified of any existing pre-Optimobile user associations.

### Breaking Changes

-   None

### Test Plan

1. Init with Optimove credentials only, setUserId
2. Init with OptiMobile credentials, observe current userId being associated during initializations


