### PR TITLE
Add xcbeautify to tidy up CI output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
     - uses: actions/checkout@v1
     - run: carthage update --use-xcframeworks --cache-builds
       name: Carthage
-    - run: xcodebuild build-for-testing -project Optimove.xcodeproj -scheme UnitTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11"
+    - name: Install xcbeautify
+      run: brew install xcbeautify
+    - run: set -o pipefail && xcodebuild build-for-testing -project Optimove.xcodeproj -scheme UnitTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11" | xcbeautify
       name: Build
-    - run: xcodebuild test-without-building -project Optimove.xcodeproj -scheme UnitTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11"
+    - run: set -o pipefail && xcodebuild test-without-building -project Optimove.xcodeproj -scheme UnitTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11" | xcbeautify
       name: Test


### PR DESCRIPTION
### Description of Changes

Clean up CI logs by piping xcodebuild output through xcbeautify.

Set the pipefail option so the eventual exit code is consistent with xcodebuild status.

### Breaking Changes

-   None

*N.B. Release steps removed as this is purely a CI tooling enhancement.*