### PR TITLE
Support for signing customers out of the app and opting out from push

### DIFF
--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -271,11 +271,6 @@ extension Optimove {
         Optimobile.clearUserAssociation()
     }
     
-    @objc public static func pushUnregister() {
-        Optimobile.pushUnregister()
-    }
-}
-
 // MARK: - Optimobile APIs
 
 extension Optimove {
@@ -309,6 +304,15 @@ extension Optimove {
     */
     @objc public func pushRegister(_ deviceToken: Data) {
         Optimobile.pushRegister(deviceToken)
+    }
+
+    /**
+        Unregister the device token with the Optimove Push service.
+     
+        Notifications will no longer be received until pushRequestDeviceToken is called again
+     */
+    @objc public static func pushUnregister() {
+        Optimobile.pushUnregister()
     }
 
     /**

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -261,15 +261,12 @@ extension Optimove {
     }
 
     private func signout() {
-        let function: (ServiceLocator) -> String? = { serviceLocator in
-            return try? serviceLocator.storage().getCustomerID()()
-        }
-        
         // Clear customerID from storage
         // Set VisitorID to InitialVisitorID
         
         Optimobile.clearUserAssociation()
     }
+}
     
 // MARK: - Optimobile APIs
 

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -260,7 +260,9 @@ extension Optimove {
         shared.signOutUser()
     }
 
-    private func signOutUser() {
+    /// Signout the user from the app
+    /// Call this function to unset the customerID and revert to an anonymous visitor
+    public func signOutUser() {
         if config.isOptimoveConfigured() {
             let function: (ServiceLocator) -> Void = { serviceLocator in
                 tryCatch {

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -264,8 +264,8 @@ extension Optimove {
         if config.isOptimoveConfigured() {
             let function: (ServiceLocator) -> Void = { serviceLocator in
                 tryCatch {
-                    serviceLocator.storage().customerID = nil
-                    serviceLocator.storage().visitorId = service.storage().initialVisitorId
+                    serviceLocator.storage().set(value: nil, key: StorageKey.customerID)
+                    serviceLocator.storage().set(value: serviceLocator.storage().initialVisitorId, key: StorageKey.visitorID)
                 }
             }
             container.resolve(function)

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -192,9 +192,9 @@ extension Optimove {
                     let user = User(userID: userID)
                     let event = try self._setUser(user, serviceLocator)
                     serviceLocator.pipeline().deliver(.report(events: [event]))
-                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
-                        serviceLocator.pipeline().deliver(.setInstallation)
-                    }
+//                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
+//                        serviceLocator.pipeline().deliver(.setInstallation)
+//                    }
                 }
             }
             container.resolve(function)
@@ -256,27 +256,19 @@ extension Optimove {
     
     /// Signout the user from the app
     ///  Call this function to unset the customerID and revert to an anonymous visitor
-    @objc public static func signout() {
-        shared.signout()
+    @objc public static func signOutUser() {
+        shared.signOutUser()
     }
 
-    private func signout() {
-        
+    private func signOutUser() {
         if config.isOptimoveConfigured() {
-            // Clear customerID from storage
-            // Set VisitorID to InitialVisitorID
-            // ?
-//            let function: (ServiceLocator) -> Void = { serviceLocator in
-//                tryCatch {
-//                    let user = User(userID: userID)
-//                    let event = try self._setUser(user, serviceLocator)
-//                    serviceLocator.pipeline().deliver(.report(events: [event]))
-//                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
-//                        serviceLocator.pipeline().deliver(.setInstallation)
-//                    }
-//                }
-//            }
-//            container.resolve(function)
+            let function: (ServiceLocator) -> Void = { serviceLocator in
+                tryCatch {
+                    serviceLocator.storage().customerID = nil
+                    serviceLocator.storage().visitorId = service.storage().initialVisitorId
+                }
+            }
+            container.resolve(function)
         }
         
         if config.isOptimobileConfigured() {

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -261,10 +261,27 @@ extension Optimove {
     }
 
     private func signout() {
-        // Clear customerID from storage
-        // Set VisitorID to InitialVisitorID
         
-        Optimobile.clearUserAssociation()
+        if config.isOptimoveConfigured() {
+            // Clear customerID from storage
+            // Set VisitorID to InitialVisitorID
+            // ?
+//            let function: (ServiceLocator) -> Void = { serviceLocator in
+//                tryCatch {
+//                    let user = User(userID: userID)
+//                    let event = try self._setUser(user, serviceLocator)
+//                    serviceLocator.pipeline().deliver(.report(events: [event]))
+//                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
+//                        serviceLocator.pipeline().deliver(.setInstallation)
+//                    }
+//                }
+//            }
+//            container.resolve(function)
+        }
+        
+        if config.isOptimobileConfigured() {
+            Optimobile.clearUserAssociation()
+        }
     }
 }
     

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -192,9 +192,9 @@ extension Optimove {
                     let user = User(userID: userID)
                     let event = try self._setUser(user, serviceLocator)
                     serviceLocator.pipeline().deliver(.report(events: [event]))
-//                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
-//                        serviceLocator.pipeline().deliver(.setInstallation)
-//                    }
+                    if UserValidator(storage: serviceLocator.storage()).validateNewUser(user) == .valid {
+                        serviceLocator.pipeline().deliver(.setInstallation)
+                    }
                 }
             }
             container.resolve(function)

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -319,7 +319,7 @@ extension Optimove {
      
         Notifications will no longer be received until pushRequestDeviceToken is called again
      */
-    @objc public static func pushUnregister() {
+    @objc public func pushUnregister() {
         Optimobile.pushUnregister()
     }
 

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -253,7 +253,27 @@ extension Optimove {
     private func _setUserEmail(_ email: String, _ serviceLocator: ServiceLocator) throws -> Event {
         return try serviceLocator.coreEventFactory().createEvent(.setUserEmail(email: email))
     }
+    
+    /// Signout the user from the app
+    ///  Call this function to unset the customerID and revert to an anonymous visitor
+    @objc public static func signout() {
+        shared.signout()
+    }
 
+    private func signout() {
+        let function: (ServiceLocator) -> String? = { serviceLocator in
+            return try? serviceLocator.storage().getCustomerID()()
+        }
+        
+        // Clear customerID from storage
+        // Set VisitorID to InitialVisitorID
+        
+        Optimobile.clearUserAssociation()
+    }
+    
+    @objc public static func pushUnregister() {
+        Optimobile.pushUnregister()
+    }
 }
 
 // MARK: - Optimobile APIs


### PR DESCRIPTION
### Description of Changes

Add new methods `signout` and `pushUnregister` to the public API

- `signout` - Unassociate the current customer with the device, returning to a anonymous visitor state
- `pushUnregister` - Opt the device out from push notifications

### Breaking Changes

-   None

### Test Plan

-  setUserId and register for push
-  call signout - observe customerId cleared for optimove and optimobile backends
-  call pushUnregister - observe device token removed from optimobile

