### PR TITLE
SDK 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.1.0
+
+- **added** `signOutUser` API - Unassociate the current customer with the device, returning to a anonymous visitor state
+
+- **added** `pushUnregister` API - Opt the device out from push notifications
+
 ## 5.0.0
 
 Major breaking update - [Migration guide](https://github.com/optimove-tech/Optimove-SDK-iOS/wiki/Migration-guide-from-3.x-to-5.x)

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '5.0.0'
+  s.version          = '5.1.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "5.0.0"
+public let SDKVersion = "5.1.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '5.0.0'
+  s.version          = '5.1.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
   s.version          = '5.1.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
-  s.description      = 'The notification service extension is used for handling notifications.'
+  s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Mobius Solutions' => 'mobile@optimove.com' }

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '5.0.0'
+  s.version          = '5.1.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -115,7 +115,7 @@ class Optimobile {
     /**
         Initialize the Optimobile SDK.
     */
-    static func initialize(config: OptimobileConfig, initialVisitorId: String) {
+    static func initialize(config: OptimobileConfig, initialVisitorId: String, initialUserId: String?) {
         if (instance !== nil) {
             assertionFailure("The OptimobileSDK has already been initialized")
         }
@@ -140,6 +140,21 @@ class Optimobile {
         DispatchQueue.global().async {
             instance!.sendDeviceInformation()
         }
+        
+        maybeAlignUserAssociation(initialUserId: initialUserId)
+    }
+    
+    fileprivate static func maybeAlignUserAssociation(initialUserId: String?) {
+        if (initialUserId == nil) {
+            return
+        }
+        
+        let optimobileUserId = OptimobileHelper.currentUserIdentifier
+        if (optimobileUserId == initialUserId) {
+            return
+        }
+            
+        Optimobile.associateUserWithInstall(userIdentifier: initialUserId!)
     }
 
     fileprivate init(config: OptimobileConfig) {
@@ -179,5 +194,5 @@ class Optimobile {
         pushHttpClient.invalidateSessionCancellingTasks(true)
         coreHttpClient.invalidateSessionCancellingTasks(true)
     }
-
+    
 }

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -57,8 +57,10 @@ typealias Logger = OptimoveCore.Logger
                 guard let visitorId = try? serviceLocator.storage().getInitialVisitorId() else {
                     return
                 }
+                
+                let userId = try? serviceLocator.storage().getCustomerID()
 
-                Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId)
+                Optimobile.initialize(config: optimobileConfig, initialVisitorId: visitorId, initialUserId: userId)
             }
         }
     }
@@ -359,5 +361,5 @@ private extension Optimove {
         }
         container.resolve(function)
     }
-
+    
 }

--- a/Shared/Tests/Sources/FileAccessible.swift
+++ b/Shared/Tests/Sources/FileAccessible.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Helps to fetch JSON files.
-protocol FileAccessible: class {
+protocol FileAccessible: AnyObject {
     /// The name of the json name.
     var fileName: String { get }
     /// Returns Data from JSON file if exists.


### PR DESCRIPTION
### Description of Changes

- [Support for signing customers out of the app and opting out from push](https://github.com/optimove-tech/Optimove-SDK-iOS/pull/64)

- [Notify Optimobile about existing user associations](https://github.com/optimove-tech/Optimove-SDK-iOS/pull/61)

- Tweaks for pod linting (Extension spec description and "using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead" for the FileAccessible test.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `pod lib lint` passes
- [x] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

~~- [ ] `README.md`~~
- [x] `CHANGELOG.md`

### Tests

- [x]    Init with Optimove credentials only, setUserId
- [x]    Init with OptiMobile credentials, observe current userId being associated during initializations
- [x]    setUserId and register for push
- [x]    call signout - observe customerId cleared for optimove and optimobile backends
- [x]    call pushUnregister - observe device token removed from optimobile


### Release:

- [x] Squash and merge to master
- [ ] Delete branch once merged
- [x] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [x] Push wiki pages to master

