### PR TITLE
Tweaks to support hybrid sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.1.1
 
-- Expose method to support hybrid SDKs
+- Expose methods to support hybrid SDKs
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.1
+
+- Expose method to support hybrid SDKs
+
 ## 5.1.0
 
 - **added** `signOutUser` API - Unassociate the current customer with the device, returning to a anonymous visitor state

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '5.1.0'
+  s.version          = '5.1.1'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "5.1.0"
+public let SDKVersion = "5.1.1"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '5.1.0'
+  s.version          = '5.1.1'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '5.1.0'
+  s.version          = '5.1.1'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -14,7 +14,7 @@ public class PushNotification: NSObject {
     internal(set) open var url: URL?
     internal(set) open var actionIdentifier: String?
 
-    public init(userInfo: [AnyHashable:Any]?) {
+    init(userInfo: [AnyHashable:Any]?) {
         self.id = 0
         self.aps = [:]
         self.data = [:]

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -14,7 +14,7 @@ public class PushNotification: NSObject {
     internal(set) open var url: URL?
     internal(set) open var actionIdentifier: String?
 
-    init(userInfo: [AnyHashable:Any]?) {
+    public init(userInfo: [AnyHashable:Any]?) {
         self.id = 0
         self.aps = [:]
         self.data = [:]
@@ -53,7 +53,7 @@ public class PushNotification: NSObject {
             url = nil
         }
     }
-    
+
     @available(iOS 10.0, *)
     convenience init(userInfo: [AnyHashable:Any]?, response: UNNotificationResponse?) {
         self.init(userInfo: userInfo)
@@ -191,17 +191,17 @@ extension Optimobile {
                           "type" : sharedInstance.pushNotificationDeviceType,
                           "iosTokenType" : iosTokenType,
                           "bundleId": bundleId] as [String : Any]
-        
+
         Optimobile.trackEvent(eventType: OptimobileEvent.PUSH_DEVICE_REGISTER, properties: parameters as [String : AnyObject], immediateFlush: true)
     }
-    
+
     /**
         Unsubscribe your device from the Optimobile Push service
     */
     static func pushUnregister() {
         Optimobile.trackEvent(eventType: OptimobileEvent.DEVICE_UNSUBSCRIBED, properties: [:], immediateFlush: true)
     }
- 
+
 // MARK: Open handling
     /**
         Track a user action triggered by a push notification
@@ -217,7 +217,7 @@ extension Optimobile {
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
         Optimobile.trackEvent(eventType: OptimobileEvent.MESSAGE_OPENED, properties:params)
     }
-    
+
     @available(iOS 9.0, *)
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?) {
         guard let userInfo = withUserInfo else {
@@ -231,7 +231,7 @@ extension Optimobile {
 
         self.pushHandleOpen(notification: notification)
     }
-  
+
     @available(iOS 10.0, *)
     internal func pushHandleOpen(withUserInfo: [AnyHashable: Any]?, response: UNNotificationResponse?) -> Bool {
         let notification = PushNotification(userInfo: withUserInfo, response: response)
@@ -241,15 +241,15 @@ extension Optimobile {
         }
 
         self.pushHandleOpen(notification: notification)
-        
+
         PendingNotificationHelper.remove(id: notification.id)
-       
+
         return true
     }
-    
+
     private func pushHandleOpen(notification: PushNotification) {
         Optimobile.pushTrackOpen(notification: notification)
-        
+
        // Handle URL pushes
 
        if let url = notification.url {
@@ -286,17 +286,17 @@ extension Optimobile {
 
         return true
     }
-    
+
     @available(iOS 10.0, *)
     private func pushHandleDismissed(notificationId: Int, dismissedAt: Date? = nil) {
         PendingNotificationHelper.remove(id: notificationId)
         self.pushTrackDismissed(notificationId: notificationId, dismissedAt: dismissedAt)
     }
-    
+
     @available(iOS 10.0, *)
     private func pushTrackDismissed(notificationId: Int, dismissedAt: Date? = nil) {
         let params = ["type": KS_MESSAGE_TYPE_PUSH, "id": notificationId]
-              
+
         if let unwrappedDismissedAt = dismissedAt {
             Optimobile.trackEvent(eventType: OptimobileEvent.MESSAGE_DISMISSED.rawValue, atTime: unwrappedDismissedAt, properties:params)
         }
@@ -304,13 +304,13 @@ extension Optimobile {
             Optimobile.trackEvent(eventType: OptimobileEvent.MESSAGE_DISMISSED, properties:params)
         }
     }
-    
+
     @available(iOS 10.0, *)
     internal func maybeTrackPushDismissedEvents() {
         if (!AppGroupsHelper.isKumulosAppGroupDefined()){
             return;
         }
-        
+
         UNUserNotificationCenter.current().getDeliveredNotifications { (notifications: [UNNotification]) in
             var actualPendingNotificationIds: [Int] = []
             for notification in notifications {
@@ -318,20 +318,20 @@ extension Optimobile {
                 if (notification.id == 0){
                     continue
                 }
-                
+
                 actualPendingNotificationIds.append(notification.id)
             }
-            
+
             let recordedPendingNotifications = PendingNotificationHelper.readAll()
-           
+
             let deletions = recordedPendingNotifications.filter({ !actualPendingNotificationIds.contains( $0.id ) })
             for deletion in deletions {
                 self.pushHandleDismissed(notificationId: deletion.id, dismissedAt: deletion.deliveredAt)
             }
-            
+
         }
     }
-    
+
 // MARK: Token handling
     fileprivate static func serializeDeviceToken(_ deviceToken: Data) -> String {
         var token: String = ""
@@ -344,7 +344,7 @@ extension Optimobile {
 
     fileprivate static func getTokenType() -> Int {
         let releaseMode = MobileProvision.releaseMode()
-        
+
         if let index =  [
             .releaseAdHoc,
             .releaseDev,
@@ -352,7 +352,7 @@ extension Optimobile {
             ].firstIndex(of: releaseMode), index > -1 {
             return releaseMode.rawValue + 1;
         }
-        
+
         return Optimobile.sharedInstance.pushNotificationProductionTokenType
     }
 }
@@ -466,24 +466,24 @@ class PushHelper {
         existingDidReceive = class_replaceMethod(klass, didReceiveSelector, kumulosDidReceive, receiveType)
         if #available(iOS 10, *) {
             let delegate = OptimoveUserNotificationCenterDelegate()
-            
+
             Optimobile.sharedInstance.notificationCenter = delegate
             UNUserNotificationCenter.current().delegate = delegate
         }
     }()
-    
+
     fileprivate func setBadge(userInfo: [AnyHashable:Any]){
         let badge: NSNumber? = OptimobileHelper.getBadgeFromUserInfo(userInfo: userInfo)
         if let newBadge = badge {
             UIApplication.shared.applicationIconBadgeNumber = newBadge.intValue
         }
     }
-    
+
     fileprivate func trackPushDelivery(notification: PushNotification) {
         if (notification.id == 0) {
             return
         }
-        
+
         let props: [String:Any] = ["type" : KS_MESSAGE_TYPE_PUSH, "id": notification.id]
         Optimobile.trackEvent(eventType: KumulosSharedEvent.MESSAGE_DELIVERED, properties:props, immediateFlush: true)
     }

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -138,22 +138,22 @@ class Optimobile {
         }
 
         DispatchQueue.global().async {
-            instance!.sendDeviceInformation()
+            instance!.sendDeviceInformation(config: config)
         }
-        
+
         maybeAlignUserAssociation(initialUserId: initialUserId)
     }
-    
+
     fileprivate static func maybeAlignUserAssociation(initialUserId: String?) {
         if (initialUserId == nil) {
             return
         }
-        
+
         let optimobileUserId = OptimobileHelper.currentUserIdentifier
         if (optimobileUserId == initialUserId) {
             return
         }
-            
+
         Optimobile.associateUserWithInstall(userIdentifier: initialUserId!)
     }
 
@@ -194,5 +194,5 @@ class Optimobile {
         pushHttpClient.invalidateSessionCancellingTasks(true)
         coreHttpClient.invalidateSessionCancellingTasks(true)
     }
-    
+
 }

--- a/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
+++ b/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
@@ -49,6 +49,10 @@ public struct OptimobileConfig {
     let deepLinkHandler : DeepLinkHandler?
 
     let baseUrlMap : ServiceUrlMap
+
+    let runtimeInfo: [String : AnyObject]?
+    let sdkInfo: [String : AnyObject]?
+    let isRelease: Bool?
 }
 
 open class OptimoveConfigBuilder: NSObject {
@@ -65,7 +69,11 @@ open class OptimoveConfigBuilder: NSObject {
     private var _deepLinkCname : URL?
     private var _deepLinkHandler : DeepLinkHandler?
     private var _baseUrlMap : ServiceUrlMap?
-    
+
+    private var _runtimeInfo : [String : AnyObject]?
+    private var _sdkInfo : [String : AnyObject]?
+    private var _isRelease : Bool?
+
     public init(optimoveCredentials: String?, optimobileCredentials: String?) {
         let optimoveCredentialsTuple = OptimoveConfigBuilder.parseOptimoveCredentials(creds: optimoveCredentials)
         let optimobileCredentialsTuple = OptimoveConfigBuilder.parseOptimobileCredentials(creds: optimobileCredentials)
@@ -88,36 +96,63 @@ open class OptimoveConfigBuilder: NSObject {
 
         _sessionIdleTimeout = 23
     }
-    
+
     @discardableResult public func setSessionIdleTimeout(seconds: UInt) -> OptimoveConfigBuilder {
         _sessionIdleTimeout = seconds
         return self
     }
-    
+
     @discardableResult public func enableInAppMessaging(inAppConsentStrategy: InAppConsentStrategy) -> OptimoveConfigBuilder {
         _inAppConsentStrategy = inAppConsentStrategy
         return self
     }
-    
+
     @discardableResult public func setInAppDeepLinkHandler(inAppDeepLinkHandlerBlock: @escaping InAppDeepLinkHandlerBlock) -> OptimoveConfigBuilder {
         _inAppDeepLinkHandlerBlock = inAppDeepLinkHandlerBlock
         return self
     }
-    
+
     @discardableResult public func setPushOpenedHandler(pushOpenedHandlerBlock: @escaping PushOpenedHandlerBlock) -> OptimoveConfigBuilder {
         _pushOpenedHandlerBlock = pushOpenedHandlerBlock
         return self
     }
-    
+
     @available(iOS 10.0, *)
     @discardableResult public func setPushReceivedInForegroundHandler(pushReceivedInForegroundHandlerBlock: @escaping PushReceivedInForegroundHandlerBlock) -> OptimoveConfigBuilder {
         _pushReceivedInForegroundHandlerBlock = pushReceivedInForegroundHandlerBlock
         return self
     }
 
-   @discardableResult public func enableDeepLinking(cname: String? = nil, _ handler: @escaping DeepLinkHandler) -> OptimoveConfigBuilder {
+    @discardableResult public func enableDeepLinking(cname: String? = nil, _ handler: @escaping DeepLinkHandler) -> OptimoveConfigBuilder {
         _deepLinkCname = URL(string: cname ?? "")
         _deepLinkHandler = handler
+
+        return self
+    }
+
+    /**
+     Internal SDK embedding API to support override of stats data in x-plat SDKs. Do not call or depend on this method in your app
+     */
+    @discardableResult public func setRuntimeInfo(runtimeInfo: [String : AnyObject]) -> OptimoveConfigBuilder {
+         _runtimeInfo = runtimeInfo
+
+         return self
+    }
+
+    /**
+     Internal SDK embedding API to support override of stats data in x-plat SDKs. Do not call or depend on this method in your app
+     */
+    @discardableResult public func setSdkInfo(sdkInfo: [String : AnyObject]) -> OptimoveConfigBuilder {
+        _sdkInfo = sdkInfo
+
+        return self
+    }
+
+    /**
+     Internal SDK embedding API to support override of stats data in x-plat SDKs. Do not call or depend on this method in your app
+     */
+    @discardableResult public func setTargetType(isRelease: Bool) -> OptimoveConfigBuilder {
+        _isRelease = isRelease
 
         return self
     }
@@ -130,7 +165,7 @@ open class OptimoveConfigBuilder: NSObject {
 
         return self
     }
-    
+
     @discardableResult public func build() -> OptimoveConfig {
         var tenantInfo : OptimoveTenantInfo?
         var optimobileConfig : OptimobileConfig?
@@ -154,7 +189,10 @@ open class OptimoveConfigBuilder: NSObject {
                 _pushReceivedInForegroundHandlerBlock: _pushReceivedInForegroundHandlerBlock,
                 deepLinkCname: _deepLinkCname,
                 deepLinkHandler: _deepLinkHandler,
-                baseUrlMap: _baseUrlMap)
+                baseUrlMap: _baseUrlMap,
+                runtimeInfo: _runtimeInfo,
+                sdkInfo: _sdkInfo,
+                isRelease: _isRelease)
         }
 
         return OptimoveConfig(


### PR DESCRIPTION
### Description of Changes

Allow x-platform SDKs to override install info: sdk id and version, runtime id and version and target type.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [x] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [x] `README.md`
- [x] `CHANGELOG.md`

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [x] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [x] Push wiki pages to master

