### PR TITLE
181470 many events crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.2
+
+- Fixed a crash when there are too many event parameters reported.
+
 ## 5.2.1
 
 - Avoid force-unwrapping of NSManagedObjectContext, which could be the reason for occasional crashes.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '5.2.1'
+  s.version          = '5.2.2'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Configurations/Configuration.swift
+++ b/OptimoveCore/Sources/Classes/Configurations/Configuration.swift
@@ -71,7 +71,6 @@ public struct OptitrackConfig: Codable, TenantInfo, EventInfo {
     public let eventCategoryName: String
     public let events: [String: EventsConfig]
     public let isEnableRealtime: Bool
-    public let maxActionCustomDimensions: Int
 
     public init(
         tenantID: Int,
@@ -79,8 +78,7 @@ public struct OptitrackConfig: Codable, TenantInfo, EventInfo {
         enableAdvertisingIdReport: Bool,
         eventCategoryName: String,
         events: [String: EventsConfig],
-        isEnableRealtime: Bool,
-        maxActionCustomDimensions: Int
+        isEnableRealtime: Bool
     ) {
         self.tenantID = tenantID
         self.optitrackEndpoint = optitrackEndpoint
@@ -88,7 +86,6 @@ public struct OptitrackConfig: Codable, TenantInfo, EventInfo {
         self.eventCategoryName = eventCategoryName
         self.events = events
         self.isEnableRealtime = isEnableRealtime
-        self.maxActionCustomDimensions = maxActionCustomDimensions
     }
 }
 

--- a/OptimoveCore/Sources/Classes/Configurations/ConfigurationBuilder.swift
+++ b/OptimoveCore/Sources/Classes/Configurations/ConfigurationBuilder.swift
@@ -59,8 +59,7 @@ private extension ConfigurationBuilder {
             enableAdvertisingIdReport: false,
             eventCategoryName: globalConfig.optitrack.eventCategoryName,
             events: events,
-            isEnableRealtime: tenantConfig.isEnableRealtime && tenantConfig.isEnableRealtimeThroughOptistream,
-            maxActionCustomDimensions: tenantConfig.optitrack.maxActionCustomDimensions
+            isEnableRealtime: tenantConfig.isEnableRealtime && tenantConfig.isEnableRealtimeThroughOptistream
         )
     }
 

--- a/OptimoveCore/Sources/Classes/Configurations/Tenant/OptitrackMetaData.swift
+++ b/OptimoveCore/Sources/Classes/Configurations/Tenant/OptitrackMetaData.swift
@@ -5,15 +5,12 @@ import Foundation
 public struct TenantOptitrackConfig: Codable, Equatable {
     public var optitrackEndpoint: URL
     public var siteId: Int
-    public var maxActionCustomDimensions: Int
 
     public init(
         optitrackEndpoint: URL,
-        siteId: Int,
-        maxActionCustomDimensions: Int
+        siteId: Int
     ) {
         self.optitrackEndpoint = optitrackEndpoint
         self.siteId = siteId
-        self.maxActionCustomDimensions = maxActionCustomDimensions
     }
 }

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "5.2.1"
+public let SDKVersion = "5.2.2"

--- a/OptimoveCore/Tests/Resources/dev.tid.107.optipush.json
+++ b/OptimoveCore/Tests/Resources/dev.tid.107.optipush.json
@@ -5,7 +5,6 @@
     "realtimeGateway": "http://173.255.119.3/",
   },
   "optitrackMetaData": {
-    "maxActionCustomDimensions": 25,
     "optitrackEndpoint": "http://104.197.238.220/",
     "siteId": 107
   },

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '5.2.1'
+  s.version          = '5.2.2'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '5.2.1'
+  s.version          = '5.2.2'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Pipeline/Pipes/ParametersDecorator.swift
+++ b/OptimoveSDK/Sources/Classes/Pipeline/Pipes/ParametersDecorator.swift
@@ -49,11 +49,9 @@ final class ParametersDecorator: Pipe {
                 return event
             }
             event.isRealtime = eventConfiguration.supportedOnRealTime
-            let limitToAddContext = configuration.optitrack.maxActionCustomDimensions - event.context.count
             return ParametersDecorator.decorateWithDefaultParameters(
                 event: event,
-                eventConfig: eventConfiguration,
-                limit: limitToAddContext
+                eventConfig: eventConfiguration
             )
         }
         return CommonOperation.report(events: decoratedEvents)
@@ -61,8 +59,7 @@ final class ParametersDecorator: Pipe {
 
     private static func decorateWithDefaultParameters(
         event: Event,
-        eventConfig: EventsConfig,
-        limit: Int
+        eventConfig: EventsConfig
     ) -> Event {
         let defaultParameters: [String: Any] = [
             Constants.Key.eventNativeMobile: Constants.Value.eventNativeMobile,
@@ -71,7 +68,6 @@ final class ParametersDecorator: Pipe {
             Constants.Key.eventPlatform: Constants.Value.eventPlatform
         ]
         defaultParameters
-            .prefix(limit)
             .filter { defaultParameter -> Bool in
                 return eventConfig.parameters[defaultParameter.key] != nil
             }.forEach { defaultParameter in

--- a/Shared/Tests/Sources/Fixture/TenantConfigFixture.swift
+++ b/Shared/Tests/Sources/Fixture/TenantConfigFixture.swift
@@ -5,10 +5,6 @@ import OptimoveCore
 
 final class TenantConfigFixture {
 
-    struct Constants {
-        static let maxActionCustomDimensions = 10
-    }
-
     func build(_ options: Options = Options.default) -> TenantConfig {
         return TenantConfig(
             realtime: tenantRealtimeConfigFixture(),
@@ -30,8 +26,7 @@ final class TenantConfigFixture {
     func tenantOptitrackConfigFixture() -> TenantOptitrackConfig {
         return TenantOptitrackConfig(
             optitrackEndpoint: StubVariables.url,
-            siteId: StubVariables.int,
-            maxActionCustomDimensions: Constants.maxActionCustomDimensions
+            siteId: StubVariables.int
         )
     }
 


### PR DESCRIPTION
### Description of Changes

When the number of parameters that are reported with an event exceeds the maximum allowed number mentioned in the mobile config file, the app crashes

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- ~~Detail any breaking changes. Breaking changes require a new major version number~~
- [ ] Check `pod lib lint` passes
- ~~Update any relevant sections of the repository wiki pages on a branch~~

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- ~~`README.md`~~
- [x] `CHANGELOG.md`

### Integration tests

*T&T Only*

- [x] Init SDK with only T&T credentials
- [x] Associate customer
- ~~Associate email~~
- [x] Track events

*Mobile Only*

- ~~Init SDK with all credentials~~
- ~~Track events~~
- ~~Associate customer (verify both backends)~~
- ~~Register for push~~
- ~~Opt-in for In-App~~
- ~~Send test push~~
- ~~Send test In-App~~
- ~~Receive / trigger deep link handler (In-App/Push)~~
- ~~Receive / trigger the content extension, render image and action buttons for push~~
- ~~Verify push opened handler~~

*Deferred Deep Links*

- ~~With app installed, trigger deep link handler~~
- ~~With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler~~

*Combined*

- ~~Track event for T&T, verify push received~~
- ~~Trigger scheduled campaign, verify push received~~
- ~~Trigger scheduled campaign, verify In-App received~~

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- ~~Push wiki pages to master~~

