### PR TITLE
Enable in-app auto-enrollment when upgrading from Kumulos to Optimove SDKs

### DIFF
--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
@@ -144,6 +144,8 @@ internal class InAppManager {
     }
     
     func userConsented() -> Bool {
+        // Note if this implementation is changed there is a usage in the main Optimobile initialisation path
+        // that should be considered.
         return UserDefaults.standard.bool(forKey: OptimobileUserDefaultsKey.IN_APP_CONSENTED.rawValue)
     }
     


### PR DESCRIPTION
### Description of Changes

The Optimobile system uses the same storage key for in-app consent as the Kumulos SDK did previously. This means in-app auto-enrollment doesn't happen when an install updates from the Kumulos to the Optimove SDK because the SDK thinks the user is already consented.

To resolve this, we detect if we are a 'new' Optimobile installation and remove the in-app consent key from storage. This enables the typical in-app consent process to take place for auto-enrollment.

Note that explicit consent management use-cases are not considered and they would end up in a non-consented state until the opt-in is sent again by the app.

---

Another approach that was considered was to change the storage key used for in-app consent, however this could potentially result in inconsistent state for existing Optimove SDK installations when they get the newer SDK version (if explicit consent management is used).

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] ~Update any relevant sections of the repository wiki pages on a branch~

### Bump versions in:

> Not bumping versions as will create a single release with in-app changes from #72 

- [ ] `README.md`
- [ ] `CHANGELOG.md`

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

