### PR TITLE
Add in-app display mode to enable pausing & resuming in-app message display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.3.0
+
+- Add ability to pause & resume in-app message display (#72)
+- Improve Kumulos to Optimove SDK upgrade path (#71)
+
 ## 5.2.2
 
 - Fixed a crash when there are too many event parameters reported.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '5.2.2'
+  s.version          = '5.3.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "5.2.2"
+public let SDKVersion = "5.3.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '5.2.2'
+  s.version          = '5.3.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '5.2.2'
+  s.version          = '5.3.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
@@ -8,6 +8,7 @@ public enum InAppMessagePresentationResult : String {
     case PRESENTED = "presented"
     case EXPIRED = "expired"
     case FAILED = "failed"
+    case PAUSED = "paused"
 }
 
 typealias kumulos_applicationPerformFetchWithCompletionHandler = @convention(c) (_ obj:Any, _ _cmd:Selector, _ application:UIApplication, _ completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Void;
@@ -18,7 +19,7 @@ typealias InAppSyncCompletionHandler = (_ result:Int) -> Void
 
 internal class InAppManager {
     
-    private var presenter: InAppPresenter
+    private(set) var presenter: InAppPresenter
     private var pendingTickleIds: NSMutableOrderedSet = NSMutableOrderedSet(capacity: 1)
     
     var messagesContext: NSManagedObjectContext? = nil;
@@ -31,8 +32,8 @@ internal class InAppManager {
     
     // MARK: Initialization
     
-    init() {
-        presenter = InAppPresenter()
+    init(_ config: OptimobileConfig) {
+        presenter = InAppPresenter(displayMode: config.inAppDefaultDisplayMode)
         syncQueue = DispatchQueue(label: "kumulos.in-app.sync")
     }
     

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile.swift
@@ -33,6 +33,11 @@ public enum InAppConsentStrategy : String {
     case explicitByUser = "ExplicitByUser"
 }
 
+public enum InAppDisplayMode : String {
+    case automatic = "automatic"
+    case paused = "paused"
+}
+
 // MARK: class
 class Optimobile {
     let urlBuilder:UrlBuilder
@@ -172,7 +177,7 @@ class Optimobile {
 
         analyticsHelper = AnalyticsHelper(apiKey: apiKey, secretKey: secretKey, baseEventsUrl: urlBuilder.urlForService(.events))
         sessionHelper = SessionHelper(sessionIdleTimeout: config.sessionIdleTimeout)
-        inAppManager = InAppManager()
+        inAppManager = InAppManager(config)
         pushHelper = PushHelper()
         badgeObserver = OptimobileBadgeObserver(callback: { (newBadgeCount) in
            KeyValPersistenceHelper.set(newBadgeCount, forKey: OptimobileUserDefaultsKey.BADGE_COUNT.rawValue)

--- a/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
@@ -89,6 +89,14 @@ public class OptimoveInApp {
         Optimobile.sharedInstance.inAppManager.updateUserConsent(consentGiven: consentGiven)
     }
     
+    public static func setDisplayMode(mode: InAppDisplayMode) {
+        Optimobile.sharedInstance.inAppManager.presenter.setDisplayMode(mode)
+    }
+
+    public static func getDisplayMode() -> InAppDisplayMode {
+        return Optimobile.sharedInstance.inAppManager.presenter.getDisplayMode()
+    }
+    
     public static func getInboxItems() -> [InAppInboxItem] {
         guard let context = Optimobile.sharedInstance.inAppManager.messagesContext else {
             return []
@@ -130,6 +138,10 @@ public class OptimoveInApp {
     }
     
     public static func presentInboxMessage(item: InAppInboxItem) -> InAppMessagePresentationResult {
+        if getDisplayMode() == .paused {
+            return .PAUSED
+        }
+
         if item.isAvailable() == false {
             return InAppMessagePresentationResult.EXPIRED
         }

--- a/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
+++ b/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
@@ -34,6 +34,7 @@ public struct OptimobileConfig {
     let sessionIdleTimeout: UInt
 
     let inAppConsentStrategy : InAppConsentStrategy
+    let inAppDefaultDisplayMode : InAppDisplayMode
     let inAppDeepLinkHandlerBlock : InAppDeepLinkHandlerBlock?
 
     let pushOpenedHandlerBlock : PushOpenedHandlerBlock?
@@ -63,6 +64,7 @@ open class OptimoveConfigBuilder: NSObject {
     private var _secretKey: String?
     private var _sessionIdleTimeout: UInt
     private var _inAppConsentStrategy = InAppConsentStrategy.notEnabled
+    private var _inAppDisplayMode = InAppDisplayMode.automatic
     private var _inAppDeepLinkHandlerBlock: InAppDeepLinkHandlerBlock?
     private var _pushOpenedHandlerBlock: PushOpenedHandlerBlock?
     private var _pushReceivedInForegroundHandlerBlock: Any?
@@ -101,10 +103,15 @@ open class OptimoveConfigBuilder: NSObject {
         _sessionIdleTimeout = seconds
         return self
     }
+    
+    @discardableResult public func enableInAppMessaging(inAppConsentStrategy: InAppConsentStrategy, defaultDisplayMode: InAppDisplayMode) -> OptimoveConfigBuilder {
+        _inAppConsentStrategy = inAppConsentStrategy
+        _inAppDisplayMode = defaultDisplayMode
+        return self
+    }
 
     @discardableResult public func enableInAppMessaging(inAppConsentStrategy: InAppConsentStrategy) -> OptimoveConfigBuilder {
-        _inAppConsentStrategy = inAppConsentStrategy
-        return self
+        return enableInAppMessaging(inAppConsentStrategy: inAppConsentStrategy, defaultDisplayMode: .automatic)
     }
 
     @discardableResult public func setInAppDeepLinkHandler(inAppDeepLinkHandlerBlock: @escaping InAppDeepLinkHandlerBlock) -> OptimoveConfigBuilder {
@@ -184,6 +191,7 @@ open class OptimoveConfigBuilder: NSObject {
                 region: _region,
                 sessionIdleTimeout: _sessionIdleTimeout,
                 inAppConsentStrategy: _inAppConsentStrategy,
+                inAppDefaultDisplayMode: _inAppDisplayMode,
                 inAppDeepLinkHandlerBlock: _inAppDeepLinkHandlerBlock,
                 pushOpenedHandlerBlock: _pushOpenedHandlerBlock,
                 _pushReceivedInForegroundHandlerBlock: _pushReceivedInForegroundHandlerBlock,


### PR DESCRIPTION
### Description of Changes

Add an in-app display mode configuration that allows pausing display of in-app messages.

All existing in-app behaviours such as queueing are performed as normal whilst display is paused, only the presentation of the message view itself is prevented.

This is exposed as a 'default' configuration option and a new API to set the behaviour at runtime.

When display was previously paused and then enabled again, any pending messages in the queue should be presented.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [ ] ~`README.md`~
- [x] `CHANGELOG.md`
- [ ] ~Update major version numbers in wiki (basic integration + push guides)~

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [x] Register for push
- [x] Opt-in for In-App
- [x] Send test push
- [x] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [x] Squash and merge to master
- [x] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

