### PR TITLE
AB#236691  OptimoveSDK Xcode 16 swift warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.1.0
+
+- Fix removed tasks to support pre 5.5 swift versions
+- Fix Xcode 16 OpitmoveSDK warnings
+
 ## 6.0.2
 
 - Fix same immediate events sent multiple times

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.0.2'
+  s.version          = '6.1.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.0.2"
+public let SDKVersion = "6.1.0"

--- a/OptimoveCore/Sources/Classes/Operations/AsyncOperation.swift
+++ b/OptimoveCore/Sources/Classes/Operations/AsyncOperation.swift
@@ -79,6 +79,10 @@ open class AsyncOperation: Operation {
     }
 }
 
+#if swift(>=5.5)
+extension AsyncOperation: @unchecked Sendable {}
+#endif
+
 open class AsyncBlockOperation: AsyncOperation {
     public typealias Closure = (AsyncBlockOperation) -> Void
 
@@ -94,3 +98,7 @@ open class AsyncBlockOperation: AsyncOperation {
         closure(self)
     }
 }
+
+#if swift(>=5.5)
+extension AsyncBlockOperation: @unchecked Sendable {}
+#endif

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.0.2'
+  s.version          = '6.1.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.0.2'
+  s.version          = '6.1.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Configuration/GlobalConfigurationDownloader.swift
+++ b/OptimoveSDK/Sources/Classes/Configuration/GlobalConfigurationDownloader.swift
@@ -35,3 +35,7 @@ final class GlobalConfigurationDownloader: AsyncOperation {
         }
     }
 }
+
+#if swift(>=5.5)
+extension GlobalConfigurationDownloader: @unchecked Sendable {}
+#endif

--- a/OptimoveSDK/Sources/Classes/Configuration/MergeRemoteConfigurationOperation.swift
+++ b/OptimoveSDK/Sources/Classes/Configuration/MergeRemoteConfigurationOperation.swift
@@ -29,3 +29,7 @@ final class MergeRemoteConfigurationOperation: AsyncOperation {
         state = .finished
     }
 }
+
+#if swift(>=5.5)
+extension MergeRemoteConfigurationOperation: @unchecked Sendable {}
+#endif

--- a/OptimoveSDK/Sources/Classes/Configuration/TenantConfigurationDownloader.swift
+++ b/OptimoveSDK/Sources/Classes/Configuration/TenantConfigurationDownloader.swift
@@ -36,3 +36,7 @@ final class TenantConfigurationDownloader: AsyncOperation {
         }
     }
 }
+
+#if swift(>=5.5)
+extension TenantConfigurationDownloader: @unchecked Sendable {}
+#endif

--- a/OptimoveSDK/Sources/Classes/CoreData/PersistentContainer.swift
+++ b/OptimoveSDK/Sources/Classes/CoreData/PersistentContainer.swift
@@ -89,6 +89,10 @@ final class PersistentContainer: NSPersistentContainer {
     }
 }
 
+#if swift(>=5.5)
+extension PersistentContainer: @unchecked Sendable {}
+#endif
+
 extension FileManager {
     func defineStoreURL(folderName: String, storeName: String) throws -> URL {
         let libraryDirectory = try unwrap(urls(for: .libraryDirectory, in: .userDomainMask).first)

--- a/OptimoveSDK/Sources/Classes/PreferenceCenter/OptimovePreferenceCenter.swift
+++ b/OptimoveSDK/Sources/Classes/PreferenceCenter/OptimovePreferenceCenter.swift
@@ -65,7 +65,6 @@ public class OptimovePreferenceCenter {
         self.storage = storage
     }
 
-    @available(iOS 13.0, *)
     public func getPreferencesAsync(completion: @escaping PreferencesGetHandler) {
         guard let config = Optimove.getConfig()?.getPreferenceCenterConfig() else {
             Logger.error("Preference center credentials are not set")
@@ -83,37 +82,35 @@ public class OptimovePreferenceCenter {
             return
         }
 
-        Task {
-            do {
-                let request = try createGetPreferencesRequest(for: customerId, with: config)
+        do {
+            let request = try createGetPreferencesRequest(for: customerId, with: config)
 
-                networkClient?.perform(request) { [self] result in
-                    switch result {
-                    case .success(let response):
-                        do {
-                            let preferences = try response.decode(to: OptimovePC.Preferences.self)
-                            DispatchQueue.main.async {
-                                completion(.success, preferences)
-                            }
-                        } catch {
-                            logFailedResponse(error)
-                            DispatchQueue.main.async {
-                                completion(.error, nil)
-                            }
+            networkClient?.perform(request) { [self] result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let preferences = try response.decode(to: OptimovePC.Preferences.self)
+                        DispatchQueue.main.async {
+                            completion(.success, preferences)
                         }
-                    case .failure(let error):
+                    } catch {
                         logFailedResponse(error)
                         DispatchQueue.main.async {
                             completion(.error, nil)
                         }
                     }
+                case .failure(let error):
+                    logFailedResponse(error)
+                    DispatchQueue.main.async {
+                        completion(.error, nil)
+                    }
                 }
+            }
 
-            } catch {
-                logFailedResponse(error)
-                DispatchQueue.main.async {
-                    completion(.error, nil)
-                }
+        } catch {
+            logFailedResponse(error)
+            DispatchQueue.main.async {
+                completion(.error, nil)
             }
         }
     }
@@ -144,8 +141,6 @@ public class OptimovePreferenceCenter {
         return (region, brandGroupId, tenantId)
     }
 
-
-    @available(iOS 13.0, *)
     public func setCustomerPreferencesAsync(completion: @escaping PreferencesSetHandler, updates: [OptimovePC.PreferenceUpdate]) {
         guard let config = Optimove.getConfig()?.getPreferenceCenterConfig() else {
             Logger.error("Preference center credentials are not set")
@@ -162,37 +157,35 @@ public class OptimovePreferenceCenter {
             return
         }
 
-        Task {
-            do {
-                let request = try createSetPreferencesRequest(for: customerId, with: config, updates: updates)
+        do {
+            let request = try createSetPreferencesRequest(for: customerId, with: config, updates: updates)
 
-                networkClient?.perform(request) { [self] result in
-                    switch result {
-                    case .success(let response):
-                        do {
-                            _ = try response.unwrap()
-                            DispatchQueue.main.async {
-                                completion(.success)
-                            }
-                        } catch {
-                            logFailedResponse(error)
-                            DispatchQueue.main.async {
-                                completion(.error)
-                            }
+            networkClient?.perform(request) { [self] result in
+                switch result {
+                case .success(let response):
+                    do {
+                        _ = try response.unwrap()
+                        DispatchQueue.main.async {
+                            completion(.success)
                         }
-                    case .failure(let error):
+                    } catch {
                         logFailedResponse(error)
                         DispatchQueue.main.async {
                             completion(.error)
                         }
                     }
+                case .failure(let error):
+                    logFailedResponse(error)
+                    DispatchQueue.main.async {
+                        completion(.error)
+                    }
                 }
+            }
 
-            } catch {
-                logFailedResponse(error)
-                DispatchQueue.main.async {
-                    completion(.error)
-                }
+        } catch {
+            logFailedResponse(error)
+            DispatchQueue.main.async {
+                completion(.error)
             }
         }
     }


### PR DESCRIPTION
### Description of Changes

- Removed tasks to support pre 5.5 swift versions
- Updated Operation extending classes with restating `@unchecked Sendable` to remove Xcode 16 warnings in OpitmoveSDK

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- ~[ ] `README.md`~
- [x] `CHANGELOG.md`

### Integration tests

_T&T Only_

- ~[ ] Init SDK with only optimove credentials~
- [x] Associate customer
- ~[ ] Associate email~
- [x] Track events

_Mobile Only_

- [x] Init SDK with all credentials
- ~[] Track events~
- [x] Associate customer (verify both backends)
- [x] Register for push
- ~[ ] Opt-in for In-App~
- [x] Send test push
- ~[ ] Send test In-App~
- ~[ ] Receive / trigger deep link handler (In-App/Push)~
- ~[ ] Receive / trigger the content extension, render image and action buttons for push~
- ~[ ] Verify push opened handler~
- [x] Verify preference center

_Deferred Deep Links_

- ~[ ] With app installed, trigger deep link handler~
- ~[ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler~

_Combined_

- ~[ ] Track event for T&T, verify push received~
- ~[ ] Trigger scheduled campaign, verify push received~
- ~[ ] Trigger scheduled campaign, verify In-App received~

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

