### PR TITLE
Support for coexistence with other SDKs that swizzle push related app delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.2.0
+
+- Add support for coexisting with other push notification SDKs by resolving race conditions when multiple SDKs swizzle the following UIApplicationDelegate methods:
+    - `UIApplicationDelegate.application(:didRegisterForRemoteNotificationsWithDeviceToken:)`
+    - `UIApplicationDelegate.application(:didFailToRegisterForRemoteNotificationsWithError:)`
+    - `UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
+- Fix swizzling forwarding for apps that use UIApplicationDelegateAdaptor
+
 ## 6.1.0
 
 - Fix invalidating sessions on NetworkClientImpl deinit

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.1.0'
+  s.version          = '6.2.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.1.0"
+public let SDKVersion = "6.2.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.1.0'
+  s.version          = '6.2.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.1.0'
+  s.version          = '6.2.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'


### PR DESCRIPTION
### Description of Changes

The SDK swizzles the following UIApplicationDelegate methods:

    UIApplicationDelegate.application(:didRegisterForRemoteNotificationsWithDeviceToken:)
    UIApplicationDelegate.application(:didFailToRegisterForRemoteNotificationsWithError:)
    UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)

This PR addresses two issues:

1. Currently, while the SDK stores and calls the original implementation from the hosting app, it doesn't account for cases where these methods are already swizzled by other SDKs. This PR ensures proper method chaining by calling any previous implementation (whether it's the original or another SDK's swizzled version).

2. The existing implementation doesn't properly handle cases where the hosting app uses `UIApplicationDelegateAdaptor` (SwiftUI apps). This PR makes sure the original implementation is always called.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [x] `README.md`
- [x] `CHANGELOG.md`

- ~[ ] Update major version numbers in wiki (basic integration + push guides)~

### Integration tests

*T&T Only*

- ~[ ] Init SDK with only T&T credentials~
- [x] Associate customer
- ~[ ] Associate email~
- ~[ ] Track events~

*Mobile Only*

- [x] Init SDK with all credentials
- ~[ ] Track events~
- [x] Associate customer (verify both backends)
- [x] Register for push
- [x] Opt-in for In-App
- [x] Send test push
- [x] Send test In-App
- [x] Receive / trigger deep link handler (In-App/Push)
- [x] Receive / trigger the content extension, render image and action buttons for push
- [x] Verify push opened handler

*Deferred Deep Links*

- [x] With app installed, trigger deep link handler
- ~[] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler~

*Combined*

- ~[ ] Track event for T&T, verify push received~
- ~[ ] Trigger scheduled campaign, verify push received~
- ~[ ] Trigger scheduled campaign, verify In-App received~

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

