### PR TITLE
Removing no-lock option from executing unit tests command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ derived_data_path = ${build_path}/derived_data
 .PHONY: setup
 setup:
 	test ${DEVELOPER_DIR}
-	brew bundle --file=./Brewfile --quiet --no-lock
+	brew bundle --file=./Brewfile --quiet
 
 .PHONY: all
 all: setup format headers test clean


### PR DESCRIPTION
### Description of Changes

Removing no-lock parameter from running unit tests command

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [ ] `OptimoveCore.podspec`
- [ ] `OptimoveNotificationServiceExtension.podspec`
- [ ] `OptimoveSDK.podspec`

- [ ] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [ ] `README.md`
- [ ] `CHANGELOG.md`

- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

