### PR TITLE
AB#247447 Handle query params in dynamic image urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.2.1
+- Resolve issue where images with query parameters in dynamic image URLs were not displaying correctly
+
 ## 6.2.0
 
 - Add support for coexisting with other push notification SDKs by resolving race conditions when multiple SDKs swizzle the following UIApplicationDelegate methods:

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.2.0'
+  s.version          = '6.2.1'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.2.0"
+public let SDKVersion = "6.2.1"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.2.0'
+  s.version          = '6.2.1'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveNotificationServiceExtension/Sources/OptimoveNotificationService.swift
+++ b/OptimoveNotificationServiceExtension/Sources/OptimoveNotificationService.swift
@@ -135,18 +135,17 @@ public class OptimoveNotificationService {
         })
     }
 
-    private class func getPictureExtension(_ pictureUrl: String?) -> String? {
+    internal class func getPictureExtension(_ pictureUrl: String?) -> String? {
         guard let pictureUrl = pictureUrl else {
             return nil
         }
-        
+
         if let url = URL(string: pictureUrl) {
             let pictureExtension = url.pathExtension
             return pictureExtension.isEmpty ? nil : "." + pictureExtension
         }
         
-        let pictureExtension = URL(fileURLWithPath: pictureUrl).pathExtension
-        return pictureExtension.isEmpty ? nil : "." + pictureExtension
+        return nil;
     }
 
     private class func loadAttachment(_ url: URL, withExtension pictureExtension: String?, completionHandler: @escaping (UNNotificationAttachment?) -> Void) {

--- a/OptimoveNotificationServiceExtension/Sources/OptimoveNotificationService.swift
+++ b/OptimoveNotificationServiceExtension/Sources/OptimoveNotificationService.swift
@@ -136,15 +136,17 @@ public class OptimoveNotificationService {
     }
 
     private class func getPictureExtension(_ pictureUrl: String?) -> String? {
-        if pictureUrl == nil {
+        guard let pictureUrl = pictureUrl else {
             return nil
         }
-        let pictureExtension = URL(fileURLWithPath: pictureUrl!).pathExtension
-        if pictureExtension == "" {
-            return nil
+        
+        if let url = URL(string: pictureUrl) {
+            let pictureExtension = url.pathExtension
+            return pictureExtension.isEmpty ? nil : "." + pictureExtension
         }
-
-        return "." + pictureExtension
+        
+        let pictureExtension = URL(fileURLWithPath: pictureUrl).pathExtension
+        return pictureExtension.isEmpty ? nil : "." + pictureExtension
     }
 
     private class func loadAttachment(_ url: URL, withExtension pictureExtension: String?, completionHandler: @escaping (UNNotificationAttachment?) -> Void) {

--- a/OptimoveNotificationServiceExtension/Tests/Sources/OptimoveNotificationServiceExtensionTests.swift
+++ b/OptimoveNotificationServiceExtension/Tests/Sources/OptimoveNotificationServiceExtensionTests.swift
@@ -1,8 +1,10 @@
 //  Copyright © 2023 Optimove. All rights reserved.
 
 import XCTest
+@testable import OptimoveNotificationServiceExtension
 
 final class OptimoveNotificationServiceExtensionTests: XCTestCase {
+    
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -24,5 +26,95 @@ final class OptimoveNotificationServiceExtensionTests: XCTestCase {
         self.measure {
             // Put the code you want to measure the time of here.
         }
+    }
+    
+    // MARK: - getPictureExtension Tests
+    
+    func testGetPictureExtension_withWebURLWithExtension() {
+        // Given a web URL with a jpg extension
+        let pictureUrl = "https://example.com/image.jpg"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertEqual(fileExtension, ".jpg")
+    }
+    
+    func testGetPictureExtension_withWebURLWithoutExtension() {
+        // Given a web URL without extension
+        let pictureUrl = "https://example.com/image"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertNil(fileExtension)
+    }
+    
+    func testGetPictureExtension_withLocalPathWithExtension() {
+        // Given a local file path with a png extension
+        let pictureUrl = "/path/to/local/image.png"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertEqual(fileExtension, ".png")
+    }
+    
+    func testGetPictureExtension_withLocalPathWithoutExtension() {
+        // Given a local file path without extension
+        let pictureUrl = "/path/to/local/image"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertNil(fileExtension)
+    }
+    
+    func testGetPictureExtension_withNil() {
+        // Given a nil URL
+        let pictureUrl: String? = nil
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertNil(fileExtension)
+    }
+    
+    func testGetPictureExtension_withInvalidURL() {
+        // Given an invalid URL with special characters
+        let pictureUrl = "https://example.com/image with spaces.jpg"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then - should still extract extension using fileURLWithPath fallback
+        XCTAssertEqual(fileExtension, ".jpg")
+    }
+    
+    func testGetPictureExtension_withSuggestedFilename() {
+        // Given a suggested filename from response
+        let suggestedFilename = "downloaded_image.png"
+
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(suggestedFilename)
+        
+        // Then
+        XCTAssertEqual(fileExtension, ".png")
+    }
+    
+    func testGetPictureExtension_withQueryParams() {
+        // Given a URL with query parameters
+        let pictureUrl = "https://example.com/image.jpeg?width=300&height=200"
+        
+        // When
+        let fileExtension = OptimoveNotificationService.getPictureExtension(pictureUrl)
+        
+        // Then
+        XCTAssertEqual(fileExtension, ".jpeg")
     }
 }

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.2.0'
+  s.version          = '6.2.1'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'


### PR DESCRIPTION
### Description of Changes

We found that urls with query parameters weren't working for push. The images were not displaying on the end user's device. 

The issue was that when URLs contained query parameters (like image.jpg?width=300), the URL's pathExtension property would incorrectly include those parameters, leading to improper extension extraction. The improved implementation separates the logic more clearly, trying both URL(string:) and fileURLWithPath approaches to ensure the correct file extension is extracted regardless of whether query parameters are present in the URL.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [ ] `OptimoveCore.podspec`
- [ ] `OptimoveNotificationServiceExtension.podspec`
- [ ] `OptimoveSDK.podspec`

- [ ] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [ ] `README.md`
- [ ] `CHANGELOG.md`

- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

