### PR TITLE
Fix - 252019 Swizzling Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## 6.2.3
+
+- Fix potential crash when handling push notifications due to method swizzling target resolution in apps using delegate forwarding patterns (such as Flutter)
+
 ## 6.2.1
+
 - Resolve issue where images with query parameters in dynamic image URLs were not displaying correctly
 
 ## 6.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix potential crash when handling push notifications due to method swizzling target resolution in apps using delegate forwarding patterns (such as Flutter)
 
+## 6.2.2
+
+- Add the Embedded messaging APIs for GetMessages, Mark as Read, Send metrics
+
 ## 6.2.1
 
 - Resolve issue where images with query parameters in dynamic image URLs were not displaying correctly

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.2.1'
+  s.version          = '6.2.3'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.2.1"
+public let SDKVersion = "6.2.3"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.2.1'
+  s.version          = '6.2.3'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.2.1'
+  s.version          = '6.2.3'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -571,19 +571,18 @@ class PushHelper {
                 }
             }
             
-            if hasInApp {
-                group.enter()
-                Optimobile.sharedInstance.inAppManager.sync { (result: Int) in
-                    DispatchQueue.main.async {
-                        if result < 0 {
-                            fetchResult = .failed
-                        } else if result > 0 {
-                            fetchResult = .newData
-                        }
-                        // No data case is default, allow override from other handler
-                        
-                        group.leave()
+            // hasInApp true
+            group.enter()
+            Optimobile.sharedInstance.inAppManager.sync { (result: Int) in
+                DispatchQueue.main.async {
+                    if result < 0 {
+                        fetchResult = .failed
+                    } else if result > 0 {
+                        fetchResult = .newData
                     }
+                    // No data case is default, allow override from other handler
+                    
+                    group.leave()
                 }
             }
             

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -352,11 +352,16 @@ extension Optimobile {
 // MARK: Swizzling
 
 private var existingDidReg: IMP?
+private var existingDidRegTarget: AnyObject?
+
 private var existingDidFailToReg: IMP?
+private var existingDidFailTarget: AnyObject?
+
 private var existingDidReceive: IMP?
+private var existingDidReceiveTarget: AnyObject?
 
 class PushHelper {
-    typealias kumulos_applicationDidRegisterForRemoteNotifications = @convention(c) (_ obj: UIApplicationDelegate, _ _cmd: Selector, _ application: UIApplication, _ deviceToken: Data) -> Void
+    typealias kumulos_applicationDidRegisterForRemoteNotifications = @convention(c) (_ obj: Any, _ _cmd: Selector, _ application: UIApplication, _ deviceToken: Data) -> Void
     typealias didRegBlock = @convention(block) (_ obj: UIApplicationDelegate, _ application: UIApplication, _ deviceToken: Data) -> Void
 
     typealias kumulos_applicationDidFailToRegisterForRemoteNotificaitons = @convention(c) (_ obj: Any, _ _cmd: Selector, _ application: UIApplication, _ error: Error) -> Void
@@ -380,9 +385,12 @@ class PushHelper {
     private func swizzleDidRegister(delegate: UIApplicationDelegate, klass: AnyClass) {
         let didRegisterSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         let regType = NSString(string: "v@:@@").utf8String
-        let regBlock: didRegBlock = { (obj: UIApplicationDelegate, application: UIApplication, deviceToken: Data) in
+        let regBlock: didRegBlock = { (obj: Any, application: UIApplication, deviceToken: Data) in
             if let _ = existingDidReg {
-                unsafeBitCast(existingDidReg, to: kumulos_applicationDidRegisterForRemoteNotifications.self)(obj, didRegisterSelector, application, deviceToken)
+                let targetObj = existingDidRegTarget ?? obj
+                if (targetObj as AnyObject).responds(to: didRegisterSelector) {
+                    unsafeBitCast(existingDidReg, to: kumulos_applicationDidRegisterForRemoteNotifications.self)(targetObj, didRegisterSelector, application, deviceToken)
+                }
             }
 
             Optimobile.pushRegister(deviceToken)
@@ -390,9 +398,20 @@ class PushHelper {
         let kumulosDidRegister = imp_implementationWithBlock(regBlock as Any)
         existingDidReg = class_replaceMethod(klass, didRegisterSelector, kumulosDidRegister, regType)
         
-        if existingDidReg == nil {
-            existingDidReg = self.getForwardingImpl(target: delegate, originalSelector: didRegisterSelector)
+        if existingDidReg != nil {
+            return
         }
+        
+        existingDidReg = self.getForwardingImpl(target: delegate, originalSelector: didRegisterSelector)
+        
+        if existingDidReg == nil {
+            return
+        }
+        
+        if let obj = delegate as? NSObject, let ft = obj.forwardingTarget(for: didRegisterSelector) {
+            existingDidRegTarget = ft as AnyObject
+        }
+        
     }
     
     private func swizzleDidFailRegister(delegate: UIApplicationDelegate, klass: AnyClass) {
@@ -402,7 +421,10 @@ class PushHelper {
         let didFailToRegType = NSString(string: "v@:@@").utf8String
         let didFailToRegBlock: didFailToRegBlock = { (obj: Any, application: UIApplication, error: Error) in
             if let _ = existingDidFailToReg {
-                unsafeBitCast(existingDidFailToReg, to: kumulos_applicationDidFailToRegisterForRemoteNotificaitons.self)(obj, didFailToRegisterSelector, application, error)
+                let targetObj = existingDidFailTarget ?? obj
+                if (targetObj as AnyObject).responds(to: didFailToRegisterSelector) {
+                    unsafeBitCast(existingDidFailToReg, to: kumulos_applicationDidFailToRegisterForRemoteNotificaitons.self)(targetObj, didFailToRegisterSelector, application, error)
+                }
             }
 
             print("Failed to register for remote notifications: \(error)")
@@ -411,8 +433,18 @@ class PushHelper {
         let kumulosDidFailToRegister = imp_implementationWithBlock(didFailToRegBlock as Any)
         existingDidFailToReg = class_replaceMethod(klass, didFailToRegisterSelector, kumulosDidFailToRegister, didFailToRegType)
         
+        if existingDidFailToReg != nil {
+            return
+        }
+        
+        existingDidFailToReg = self.getForwardingImpl(target: delegate, originalSelector: didFailToRegisterSelector)
+        
         if existingDidFailToReg == nil {
-            existingDidFailToReg = self.getForwardingImpl(target: delegate, originalSelector: didFailToRegisterSelector)
+            return
+        }
+        
+        if let obj = delegate as? NSObject, let ft = obj.forwardingTarget(for: didFailToRegisterSelector) {
+            existingDidFailTarget = ft as AnyObject
         }
     }
     
@@ -420,66 +452,24 @@ class PushHelper {
         // iOS9+ content-available handler
         let didReceiveSelector = #selector(UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
         let receiveType = NSString(string: "v@:@@@?").utf8String
-        let didReceive: didReceiveBlock = { (obj: Any, _ application: UIApplication, userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) in
-            let notification = PushNotification(userInfo: userInfo)
-            let hasInApp = notification.inAppDeepLink() != nil
-
-            self.setBadge(userInfo: userInfo)
-            self.trackPushDelivery(notification: notification)
-
-            if existingDidReceive == nil, !hasInApp {
-                // Nothing to do
-                completionHandler(.noData)
-                return
-            } else if existingDidReceive != nil, !hasInApp {
-                // Only existing delegate work to do
-                unsafeBitCast(existingDidReceive, to: kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler.self)(obj, didReceiveSelector, application, userInfo, completionHandler)
-                return
-            }
-
-            var fetchResult: UIBackgroundFetchResult = .noData
-            let group = DispatchGroup()
-
-            if existingDidReceive != nil {
-                group.enter()
-                DispatchQueue.main.async {
-                    unsafeBitCast(existingDidReceive, to: kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler.self)(obj, didReceiveSelector, application, userInfo, { (result: UIBackgroundFetchResult) in
-                        DispatchQueue.main.async {
-                            if fetchResult == .noData {
-                                fetchResult = result
-                            }
-
-                            group.leave()
-                        }
-                    })
-                }
-            }
-            
-            if hasInApp {
-                group.enter()
-                Optimobile.sharedInstance.inAppManager.sync { (result: Int) in
-                    DispatchQueue.main.async {
-                        if result < 0 {
-                            fetchResult = .failed
-                        } else if result > 0 {
-                            fetchResult = .newData
-                        }
-                        // No data case is default, allow override from other handler
-
-                        group.leave()
-                    }
-                }
-            }
-
-            group.notify(queue: .main) {
-                completionHandler(fetchResult)
-            }
-        }
+        let didReceive = createDidReceiveBlock(didReceiveSelector: didReceiveSelector)
+        
         let kumulosDidReceive = imp_implementationWithBlock(unsafeBitCast(didReceive, to: AnyObject.self))
         existingDidReceive = class_replaceMethod(klass, didReceiveSelector, kumulosDidReceive, receiveType)
         
+        if existingDidReceive != nil {
+            return
+        }
+        
+        existingDidReceive = self.getForwardingImpl(target: delegate, originalSelector: didReceiveSelector)
+        
+        
         if existingDidReceive == nil {
-            existingDidReceive = self.getForwardingImpl(target: delegate, originalSelector: didReceiveSelector)
+            return
+        }
+        
+        if let obj = delegate as? NSObject, let ft = obj.forwardingTarget(for: didReceiveSelector) {
+            existingDidReceiveTarget = ft as AnyObject
         }
     }
     
@@ -531,5 +521,75 @@ class PushHelper {
 
         let props: [String: Any] = ["type": KS_MESSAGE_TYPE_PUSH, "id": notification.id]
         Optimobile.trackEvent(eventType: OptimobileEvent.MESSAGE_DELIVERED, properties: props, immediateFlush: true)
+    }
+
+    private func createDidReceiveBlock(didReceiveSelector: Selector) -> didReceiveBlock {
+        return { (obj: Any, application: UIApplication, userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) in
+            let notification = PushNotification(userInfo: userInfo)
+            let hasInApp = notification.inAppDeepLink() != nil
+            
+            self.setBadge(userInfo: userInfo)
+            self.trackPushDelivery(notification: notification)
+                        
+            if existingDidReceive == nil, !hasInApp {
+                // Nothing to do
+                completionHandler(.noData)
+                return
+            }
+            
+            if existingDidReceive != nil, !hasInApp {
+                // Only existing delegate work to do
+                let targetObj = existingDidReceiveTarget ?? obj
+                if (targetObj as AnyObject).responds(to: didReceiveSelector) {
+                    unsafeBitCast(existingDidReceive, to: kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler.self)(targetObj, didReceiveSelector, application, userInfo, completionHandler)
+                }
+                
+                return
+            }
+            
+            var fetchResult: UIBackgroundFetchResult = .noData
+            let group = DispatchGroup()
+            
+            if existingDidReceive != nil {
+                group.enter()
+                DispatchQueue.main.async {
+                    let targetObj = existingDidReceiveTarget ?? obj
+                    if (targetObj as AnyObject).responds(to: didReceiveSelector) {
+                        
+                        unsafeBitCast(existingDidReceive, to: kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler.self)(targetObj, didReceiveSelector, application, userInfo, { (result: UIBackgroundFetchResult) in
+                            DispatchQueue.main.async {
+                                if fetchResult == .noData {
+                                    fetchResult = result
+                                }
+                                
+                                group.leave()
+                            }
+                        })
+                    } else {
+                        group.leave()
+                    }
+                }
+            }
+            
+            if hasInApp {
+                group.enter()
+                Optimobile.sharedInstance.inAppManager.sync { (result: Int) in
+                    DispatchQueue.main.async {
+                        if result < 0 {
+                            fetchResult = .failed
+                        } else if result > 0 {
+                            fetchResult = .newData
+                        }
+                        // No data case is default, allow override from other handler
+                        
+                        group.leave()
+                    }
+                }
+            }
+            
+            group.notify(queue: .main) {
+                completionHandler(fetchResult)
+            }
+        }
     }
 }

--- a/OptimoveSDK/Sources/Classes/Optimove.swift
+++ b/OptimoveSDK/Sources/Classes/Optimove.swift
@@ -118,7 +118,7 @@ typealias Logger = OptimoveCore.Logger
         setCredentialsInternal(optimoveCredentials: optimoveCredentials, optimobileCredentials: optimobileCredentials)
     }
 
-    public static func setCredentials(optimoveCredentials: String?, optimobileCredentials: String?, preferenceCenterCredentials: String?, embeddedMessagingCredentials: String?) {
+    public static func setCredentials(optimoveCredentials: String?, optimobileCredentials: String?, preferenceCenterCredentials: String?, embeddedMessagingCredentials: String? = nil) {
         setCredentialsInternal(
             optimoveCredentials: optimoveCredentials,
             optimobileCredentials: optimobileCredentials,


### PR DESCRIPTION
### Description of Changes

Fixes a crash that occurred when handling push notifications in apps using delegate forwarding (e.g., via method swizzling or proxying the UIApplicationDelegate).

Previously, the SDK assumed that UIApplicationDelegate methods such as:

```
application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
application(_:didFailToRegisterForRemoteNotificationsWithError:)
application(_:didReceiveRemoteNotification:fetchCompletionHandler:)
```
...were directly implemented on the app delegate. When these methods were forwarded to another object (e.g., by analytics or debugging tools), the SDK attempted to call them unsafely, leading to crashes if they were not implemented.

Fix

- Introduced a check for a forwarding target using `forwardingTarget(for:)` before invoking the original implementation.
- Stored both the original method `IMP` and its forwarding `target` to ensure the method is only called if the object truly responds to it.
- Added runtime safety to all three delegate methods during swizzling.


### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [x] `README.md`
- [x] `CHANGELOG.md`

~~- [] Update major version numbers in wiki (basic integration + push guides)~~

### Integration tests

*T&T Only*

~~- [ ] Init SDK with only T&T credentials~~
~~- [ ] Associate customer~~
~~- [ ] Associate email~~
~~- [ ] Track events~~

*Mobile Only*

- [x] Init SDK with all credentials
- [x] Track events
- [x] Associate customer (verify both backends)
- [x] Register for push
- [x] Opt-in for In-App
- [x] Send test push
- [x] Send test In-App
~~- [ ] Receive / trigger deep link handler (In-App/Push)~~
~~- [] Receive / trigger the content extension, render image and action buttons for push~~
~~- [ ] Verify push opened handler~~

*Deferred Deep Links*

~~- [ ] With app installed, trigger deep link handler~~
~~- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler~~

*Combined*

~~- [ ] Track event for T&T, verify push received~~
~~- [ ] Trigger scheduled campaign, verify push received~~
~~- [ ] Trigger scheduled campaign, verify In-App received~~

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

