### PR TITLE
AB#261534 in app ccrm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.0
+
+- Add In-App Message Interceptor API `OptimoveInApp.setInAppMessageInterceptor(_:)` to allow apps to control when in-app messages are shown or suppressed based on custom logic. If no decision is made within the timeout (default 5s), the message is automatically suppressed.
+
 ## 6.2.6
 
 - Remove semaphore wait in session end to avoid QoS inversion during background flush

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.2.6'
+  s.version          = '6.3.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.2.6"
+public let SDKVersion = "6.3.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.2.6'
+  s.version          = '6.3.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.2.6'
+  s.version          = '6.3.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
@@ -44,15 +44,10 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
     }
 
     func setDisplayMode(_ mode: InAppDisplayMode) {
-        ensureMain { self.setDisplayMode_onMain(mode) }
-    }
-
-    private func setDisplayMode_onMain(_ mode: InAppDisplayMode) {
-        assertOnMainThread()
-        let resumed = mode != displayMode && mode != .paused
-        displayMode = mode
-        if resumed {
-            presentFromQueue_onMain()
+        ensureMain {
+            let resumed = mode != displayMode && mode != .paused
+            displayMode = mode
+            if resumed { presentFromQueue() } // safe: runs inline when already on main
         }
     }
 

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
@@ -45,9 +45,9 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
 
     func setDisplayMode(_ mode: InAppDisplayMode) {
         ensureMain {
-            let resumed = mode != displayMode && mode != .paused
-            displayMode = mode
-            if resumed { presentFromQueue() } // safe: runs inline when already on main
+            let resumed = mode != self.displayMode && mode != .paused
+            self.displayMode = mode
+            if resumed { self.presentFromQueue() }
         }
     }
 

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
@@ -107,9 +107,8 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
         }
 
         let notShowingCurrentTickle = currentMessage != nil
-            && messageQueue.count > 0
             && currentMessage!.id != (messageQueue[0] as! InAppMessage).id
-            && (messageQueue[0] as! InAppMessage).id == pendingTickleIds.firstObject as? Int64
+            && (messageQueue[0] as! InAppMessage).id == pendingTickleIds[0] as! Int64
 
         let queueNotEmptyAndNotShowingAnything = currentMessage == nil && messageQueue.count > 0
 

--- a/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
@@ -77,6 +77,7 @@ public typealias InboxSummaryBlock = (InAppInboxSummary?) -> Void
 
 public enum OptimoveInApp {
     private static var _inboxUpdatedHandlerBlock: InboxUpdatedHandlerBlock?
+    private static var _inAppMessageInterceptor: InAppMessageInterceptor?
 
     public static func updateConsent(forUser consentGiven: Bool) {
         if Optimobile.inAppConsentStrategy != InAppConsentStrategy.explicitByUser {
@@ -188,4 +189,32 @@ public enum OptimoveInApp {
             }
         }
     }
+
+    // MARK: Interceptor API
+
+    public static func setInAppMessageInterceptor(_ interceptor: InAppMessageInterceptor) {
+        _inAppMessageInterceptor = interceptor
+    }
+
+    static func getInAppMessageInterceptor() -> InAppMessageInterceptor? {
+        return _inAppMessageInterceptor
+    }
+}
+
+// MARK: - Interceptor Protocols
+
+public protocol InAppMessageInterceptor {
+    // Async decision, call either decision.show() or decision.suppress()
+    func processMessage(data: [String: Any]?, decision: InAppMessageInterceptorDecision)
+
+    func getTimeoutMs() -> Int
+}
+
+public protocol InAppMessageInterceptorDecision {
+    func show()
+    func suppress()
+}
+
+public extension InAppMessageInterceptor {
+    func getTimeoutMs() -> Int { 5000 }
 }


### PR DESCRIPTION
# User description
### Description of Changes

Add In-App Message Interceptor API OptimoveInApp.setInAppMessageInterceptor(_:) to allow apps to control when in-app messages are shown or suppressed based on custom logic. If no decision is made within the timeout (default 5s), the message is automatically suppressed.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [ ] `README.md`
- [x] `CHANGELOG.md`

- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a new In-App Message Interceptor API, <code>OptimoveInApp.setInAppMessageInterceptor(_:)</code>, allowing applications to control the display or suppression of in-app messages based on custom logic. Refactor the <code>InAppPresenter</code> to integrate this interception mechanism, ensuring robust and thread-safe handling of message presentation and queuing.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-iOS/131?tool=ast&topic=In-App+Message+Interception>In-App Message Interception</a>
        </td><td>Implement the <code>OptimoveInApp.setInAppMessageInterceptor(_:)</code> API, enabling custom logic to decide whether to show or suppress in-app messages, with a default 5-second timeout for decision. This includes adding <code>InAppMessageInterceptor</code> and <code>InAppMessageInterceptorDecision</code> protocols, and integrating the interception flow within <code>InAppPresenter</code> by introducing an <code>InterceptionDecision</code> class and methods like <code>applyMessageInterception</code>, <code>handleShowDecision</code>, and <code>handleSuppressDecision</code>. Additionally, refactor internal message handling in <code>InAppPresenter</code> to use <code>ensureMain</code> and <code>assertOnMainThread</code> for improved thread safety and clarity, removing the <code>messageQueueLock</code> semaphore.<details><summary>Modified files (2)</summary><ul><li>OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift</li>
<li>OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>konstantin_a@optimove.com</td><td>Fixed-an-issue-fix-wit...</td><td>October 08, 2024</td></tr>
<tr><td>eli_g@optimove.com</td><td>rc-5.6.0-84</td><td>December 07, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-iOS/131?tool=ast&topic=Version+Updates>Version Updates</a>
        </td><td>Update the SDK version from <code>6.2.6</code> to <code>6.3.0</code> across all relevant podspec files and the <code>SDKVersion.swift</code> constant, and document the new In-App Message Interceptor API in the <code>CHANGELOG.md</code>.<details><summary>Modified files (5)</summary><ul><li>OptimoveSDK.podspec</li>
<li>OptimoveCore/Sources/Classes/Constants/SDKVersion.swift</li>
<li>OptimoveCore.podspec</li>
<li>OptimoveNotificationServiceExtension.podspec</li>
<li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>konstantin_a@optimove.com</td><td>Updated-version-to-6.2.6</td><td>October 02, 2025</td></tr>
<tr><td>adamball1</td><td>bump-version-numbers-f...</td><td>July 24, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/optimove-tech/Optimove-SDK-iOS/131?tool=ast>(Baz)</a>.